### PR TITLE
Support other Azure clouds outside of AzurePublicCloud

### DIFF
--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -23,7 +23,7 @@ func (s *staticTokenCredential) GetToken(ctx context.Context, options policy.Tok
 }
 
 func createCred(fixedtoken string) (azcore.TokenCredential, error) {
-	// test change 2
+	this breaks teh build
 	var creds []azcore.TokenCredential
 
 	{

--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -23,6 +23,7 @@ func (s *staticTokenCredential) GetToken(ctx context.Context, options policy.Tok
 }
 
 func createCred(fixedtoken string) (azcore.TokenCredential, error) {
+	// test change
 	var creds []azcore.TokenCredential
 
 	{

--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -23,7 +23,6 @@ func (s *staticTokenCredential) GetToken(ctx context.Context, options policy.Tok
 }
 
 func createCred(fixedtoken string) (azcore.TokenCredential, error) {
-	this breaks teh build
 	var creds []azcore.TokenCredential
 
 	{

--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -28,7 +28,7 @@ func createCred(fixedtoken string, opts *azcore.ClientOptions) (azcore.TokenCred
 	var creds []azcore.TokenCredential
 
 	// From azure sdk for go docs:
-	//	  DisableInstanceDiscovery should be set true only by applications authenticating in
+	//    DisableInstanceDiscovery should be set true only by applications authenticating in
 	//    disconnected clouds, or private clouds such as Azure Stack.
 	disableInstanceDiscovery := false
 	if !(reflect.DeepEqual(opts.Cloud, cloud.AzurePublic) || reflect.DeepEqual(opts.Cloud, cloud.AzureGovernment) || reflect.DeepEqual(opts.Cloud, cloud.AzureChina)) {

--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
@@ -22,9 +24,18 @@ func (s *staticTokenCredential) GetToken(ctx context.Context, options policy.Tok
 	}, nil
 }
 
-func createCred(fixedtoken string) (azcore.TokenCredential, error) {
+func createCred(fixedtoken string, opts *azcore.ClientOptions) (azcore.TokenCredential, error) {
 	var creds []azcore.TokenCredential
 
+	// From azure sdk for go docs:
+	//	  DisableInstanceDiscovery should be set true only by applications authenticating in
+	//    disconnected clouds, or private clouds such as Azure Stack.
+	disableInstanceDiscovery := false
+	if !(reflect.DeepEqual(opts.Cloud, cloud.AzurePublic) || reflect.DeepEqual(opts.Cloud, cloud.AzureGovernment) || reflect.DeepEqual(opts.Cloud, cloud.AzureChina)) {
+		disableInstanceDiscovery = true
+	}
+
+	// Add more credentials to the array here if needed
 	{
 		if fixedtoken != "" {
 			creds = append(creds, &staticTokenCredential{fixedtoken})
@@ -39,15 +50,22 @@ func createCred(fixedtoken string) (azcore.TokenCredential, error) {
 	}
 
 	{
-
-		cred, err := azidentity.NewInteractiveBrowserCredential(nil)
+		interactiveOptions := azidentity.InteractiveBrowserCredentialOptions{
+			ClientOptions:            *opts,
+			DisableInstanceDiscovery: disableInstanceDiscovery,
+		}
+		cred, err := azidentity.NewInteractiveBrowserCredential(&interactiveOptions)
 		if err == nil {
 			creds = append(creds, cred)
 		}
 	}
 
 	{
-		cred, err := azidentity.NewDeviceCodeCredential(nil)
+		deviceOptions := azidentity.DeviceCodeCredentialOptions{
+			ClientOptions:            *opts,
+			DisableInstanceDiscovery: disableInstanceDiscovery,
+		}
+		cred, err := azidentity.NewDeviceCodeCredential(&deviceOptions)
 		if err == nil {
 			creds = append(creds, cred)
 		}

--- a/cmd/bastion-tunnel/cred.go
+++ b/cmd/bastion-tunnel/cred.go
@@ -23,7 +23,7 @@ func (s *staticTokenCredential) GetToken(ctx context.Context, options policy.Tok
 }
 
 func createCred(fixedtoken string) (azcore.TokenCredential, error) {
-	// test change
+	// test change 2
 	var creds []azcore.TokenCredential
 
 	{

--- a/cmd/bastion-tunnel/main.go
+++ b/cmd/bastion-tunnel/main.go
@@ -8,6 +8,8 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	log "github.com/sirupsen/logrus"
 	"github.com/tg123/azbastion/pkg/azbastion"
 	"github.com/urfave/cli/v2"
@@ -182,6 +184,10 @@ func main() {
 		},
 	}
 
+	azureOpts := azcore.ClientOptions{
+		Cloud: cloud.AzurePublic,
+	}
+
 	requiredflags := []string{
 		"subscription",
 		"group",
@@ -225,7 +231,7 @@ func main() {
 				}
 			}
 
-			cred, err := createCred(config.token)
+			cred, err := createCred(config.token, &azureOpts)
 			if err != nil {
 				return err
 			}
@@ -243,7 +249,7 @@ func main() {
 			}
 
 			log.Printf("querying bastion %s/%s/%s", config.subscription, config.group, config.name)
-			b, err := azbastion.NewFromArm(cred, config.subscription, config.group, config.name)
+			b, err := azbastion.NewFromArm(cred, config.subscription, config.group, config.name, &azureOpts)
 			if err != nil {
 				return err
 			}

--- a/cmd/bastion-tunnel/main.go
+++ b/cmd/bastion-tunnel/main.go
@@ -281,7 +281,7 @@ func main() {
 
 					go func(conn net.Conn) {
 						defer conn.Close()
-						t, err := b.NewTunnelSession(config.targetAddr, uint16(config.targetPort))
+						t, err := b.NewTunnelSession(config.targetAddr, uint16(config.targetPort), fmt.Sprintf("%s/.default", azureOpts.Cloud.Services[cloud.ResourceManager].Endpoint))
 						if err != nil {
 							log.Errorf("error creating tunnel session: %v", err)
 							return

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -35,7 +35,7 @@ func NewFromDnsName(cred azcore.TokenCredential, subscriptionID string, resource
 }
 
 func NewFromArm(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string) (*Bastion, error) {
-	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, nil, sdfsdfs sdfsdkfjsdkfjdskfdsf)()()())
+	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, nil, sdfsdfs sdfsdkfjsdkfjdskfdsf)()()()aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	"nhooyr.io/websocket"
@@ -35,7 +36,12 @@ func NewFromDnsName(cred azcore.TokenCredential, subscriptionID string, resource
 }
 
 func NewFromArm(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string) (*Bastion, error) {
-	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, nil, sdfsdfs sdfsdkfjsdkfjdskfdsf)()()()aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+	return NewFromArmClientOptions(cred, subscriptionID, resourceGroupName, bastionHostName, azcore.ClientOptions{})
+
+}
+
+func NewFromArmClientOptions(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string, clientOptions azcore.ClientOptions) (*Bastion, error) {
+	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, &arm.ClientOptions{ClientOptions: clientOptions})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -110,7 +110,6 @@ func (b *Bastion) NewTunnelSession(targetHost string, port uint16, scope string)
 		return nil, err
 	}
 
-	fmt.Printf("About to ")
 	wsUrl := fmt.Sprintf("wss://%v/webtunnelv2/%v?X-Node-Id=%v", b.bastionDns, s.WebsocketToken, s.NodeID)
 	ws, _, err := websocket.Dial(context.Background(), wsUrl, &websocket.DialOptions{
 		CompressionMode: websocket.CompressionDisabled,

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -35,7 +35,7 @@ func NewFromDnsName(cred azcore.TokenCredential, subscriptionID string, resource
 }
 
 func NewFromArm(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string) (*Bastion, error) {
-	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, nil)
+	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, nil, sdfsdfs sdfsdkfjsdkfjdskfdsf)()()())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -137,7 +137,6 @@ type sessionToken struct {
 func (b *Bastion) newSessionToken(targetHost string, port uint16, scope string) (*sessionToken, error) {
 
 	token, err := b.cred.GetToken(context.Background(), policy.TokenRequestOptions{
-		//Scopes: []string{"https://management.azure.com/.default"}, // TODO better scope
 		Scopes: []string{scope},
 	})
 

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -110,6 +110,7 @@ func (b *Bastion) NewTunnelSession(targetHost string, port uint16) (*TunnelSessi
 		return nil, err
 	}
 
+	fmt.Printf("About to ")
 	wsUrl := fmt.Sprintf("wss://%v/webtunnelv2/%v?X-Node-Id=%v", b.bastionDns, s.WebsocketToken, s.NodeID)
 	ws, _, err := websocket.Dial(context.Background(), wsUrl, &websocket.DialOptions{
 		CompressionMode: websocket.CompressionDisabled,
@@ -137,7 +138,8 @@ type sessionToken struct {
 func (b *Bastion) newSessionToken(targetHost string, port uint16) (*sessionToken, error) {
 
 	token, err := b.cred.GetToken(context.Background(), policy.TokenRequestOptions{
-		Scopes: []string{"https://management.azure.com/.default"}, // TODO better scope
+		//Scopes: []string{"https://management.azure.com/.default"}, // TODO better scope
+		Scopes: []string{"https://management.usgovcloudapi.net/.default"}, // TODO better scope
 	})
 
 	if err != nil {

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -35,13 +35,8 @@ func NewFromDnsName(cred azcore.TokenCredential, subscriptionID string, resource
 	}, nil
 }
 
-func NewFromArm(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string) (*Bastion, error) {
-	return NewFromArmClientOptions(cred, subscriptionID, resourceGroupName, bastionHostName, azcore.ClientOptions{})
-
-}
-
-func NewFromArmClientOptions(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string, clientOptions azcore.ClientOptions) (*Bastion, error) {
-	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, &arm.ClientOptions{ClientOptions: clientOptions})
+func NewFromArm(cred azcore.TokenCredential, subscriptionID string, resourceGroupName string, bastionHostName string, azureClientOptions *azcore.ClientOptions) (*Bastion, error) {
+	clientFactory, err := armnetwork.NewClientFactory(subscriptionID, cred, &arm.ClientOptions{ClientOptions: *azureClientOptions})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azbastion/bastion.go
+++ b/pkg/azbastion/bastion.go
@@ -87,7 +87,7 @@ func (t *TunnelSession) Close() error {
 	return nil
 }
 
-func (b *Bastion) NewTunnelSession(targetHost string, port uint16) (*TunnelSession, error) {
+func (b *Bastion) NewTunnelSession(targetHost string, port uint16, scope string) (*TunnelSession, error) {
 
 	if b.bastionArm != nil {
 		if b.bastionArm.Properties != nil {
@@ -105,7 +105,7 @@ func (b *Bastion) NewTunnelSession(targetHost string, port uint16) (*TunnelSessi
 		}
 	}
 
-	s, err := b.newSessionToken(targetHost, port)
+	s, err := b.newSessionToken(targetHost, port, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +135,11 @@ type sessionToken struct {
 	WebsocketToken       string   `json:"websocketToken"`
 }
 
-func (b *Bastion) newSessionToken(targetHost string, port uint16) (*sessionToken, error) {
+func (b *Bastion) newSessionToken(targetHost string, port uint16, scope string) (*sessionToken, error) {
 
 	token, err := b.cred.GetToken(context.Background(), policy.TokenRequestOptions{
 		//Scopes: []string{"https://management.azure.com/.default"}, // TODO better scope
-		Scopes: []string{"https://management.usgovcloudapi.net/.default"}, // TODO better scope
+		Scopes: []string{scope},
 	})
 
 	if err != nil {


### PR DESCRIPTION
In order to support clouds other than AzurePublicCloud azbastion needs to allow clients to specify additional parameters via the `azcore.ClientOptions` object. Refactor azbastion to allow clients to utilize this feature if they desire.